### PR TITLE
Implement encoding of addresses from public keys

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -5,6 +5,7 @@ github.com/aead/siphash v1.0.1/go.mod h1:Nywa3cDsYNNK3gaciGTWPwHt0wlpNV15vwmswBA
 github.com/armon/consul-api v0.0.0-20180202201655-eb2c6b5be1b6/go.mod h1:grANhF5doyWs3UAsr3K4I6qtAmlQcZDesFNEHPZAzj8=
 github.com/btcsuite/btcd v0.20.1-beta h1:Ik4hyJqN8Jfyv3S4AGBOmyouMsYE3EdYODkMbQjwPGw=
 github.com/btcsuite/btcd v0.20.1-beta/go.mod h1:wVuoA8VJLEcwgqHBwHmzLRazpKxTv13Px/pDuV7OomQ=
+github.com/btcsuite/btclog v0.0.0-20170628155309-84c8d2346e9f h1:bAs4lUbRJpnnkd9VhRV3jjAVU7DJVjMaK+IsvSeZvFo=
 github.com/btcsuite/btclog v0.0.0-20170628155309-84c8d2346e9f/go.mod h1:TdznJufoqS23FtqVCzL0ZqgP5MqXbb4fg/WgDys70nA=
 github.com/btcsuite/btcutil v0.0.0-20190425235716-9e5f4b9a998d/go.mod h1:+5NJ2+qvTyV9exUAL/rxXi3DcLg2Ts+ymUAY5y4NvMg=
 github.com/btcsuite/btcutil v1.0.3-0.20200713135911-4649e4b73b34 h1:tyHQjooNSvGmKffWEyJyJWdA+c1iGEOKqj6h1rHKhlY=

--- a/pb/v1/service.proto
+++ b/pb/v1/service.proto
@@ -15,8 +15,21 @@ service CoinService {
   // reason.
   rpc ValidateAddress(ValidateAddressRequest) returns (ValidateAddressResponse) {}
 
-  // DeriveExtendedKey
+  // DeriveExtendedKey accepts a base58-encoded serialized extended key and
+  // a derivation path, and returns a child extended key derived according to
+  // BIP0032 derivation rules.
   rpc DeriveExtendedKey(DeriveExtendedKeyRequest) returns (DeriveExtendedKeyResponse) {}
+
+  // EncodeAddress accepts a serialized public key and an encoding format,
+  // and returns the encoded address as a string.
+  //
+  // Both compressed as well as uncompressed public keys are supported,
+  // although they are internally converted to the right format before
+  // encoding the address.
+  //
+  // The method also takes in the chain parameters for using network-specific
+  // HD version bytes during encoding.
+  rpc EncodeAddress(EncodeAddressRequest) returns (EncodeAddressResponse) {}
 }
 
 // BitcoinNetwork enumerates the list of all supported Bitcoin networks. It
@@ -100,4 +113,38 @@ message DeriveExtendedKeyResponse {
   //
   // This field is 32 bytes long.
   bytes chain_code = 3;
+}
+
+// AddressEncoding enumerates the list of all supported encoding formats, for
+// serializing addresses.
+//
+// It is agnostic of the chain parameters.
+enum AddressEncoding {
+  ADDRESS_ENCODING_UNSPECIFIED  = 0;  // Fallback value if unrecognized / unspecified
+  ADDRESS_ENCODING_P2PKH        = 1;  // Pay-to-PubKey-Hash
+  ADDRESS_ENCODING_P2SH_P2WPKH  = 2;  // Pay-to-Witness-PubKey-Hash in Pay-to-Script-Hash
+  ADDRESS_ENCODING_P2WPKH       = 3;  // Pay-to-Witness-PubKey-Hash
+}
+
+// EncodeAddressRequest defines the input request passed to EncodeAddress
+// RPC method.
+message EncodeAddressRequest {
+  // Serialized public key from which the address must be encoded.
+  //
+  // This field must be 33 bytes long, for compressed keys, or 65 bytes long
+  // for uncompressed keys.
+  bytes public_key = 1;
+
+  // Address encoding scheme to use.
+  AddressEncoding encoding = 3;
+
+  // Chain params to identify the coin and network to be used for encoding the
+  // address.
+  ChainParams chain_params = 4;
+}
+
+// EncodeAddressResponse wraps the output response of EncodeAddress RPC.
+message EncodeAddressResponse {
+  // Address serialized from the given public key, using the specified encoding.
+  string address = 2;
 }

--- a/pkg/bitcoin/address.go
+++ b/pkg/bitcoin/address.go
@@ -3,6 +3,9 @@ package bitcoin
 import (
 	"context"
 
+	"github.com/btcsuite/btcd/btcec"
+	"github.com/btcsuite/btcd/txscript"
+
 	"github.com/btcsuite/btcd/chaincfg"
 	"github.com/btcsuite/btcutil"
 	pb "github.com/ledgerhq/lama-bitcoin-svc/pb/v1"
@@ -33,6 +36,80 @@ func (s *Service) ValidateAddress(
 		Address: addr.EncodeAddress(), // Normalize the original address
 		IsValid: true,
 	}, nil
+}
+
+func (s *Service) EncodeAddress(
+	ctx context.Context, request *pb.EncodeAddressRequest,
+) (*pb.EncodeAddressResponse, error) {
+	chainParams, err := getChainParams(request.ChainParams)
+	if err != nil {
+		return nil, status.Errorf(codes.InvalidArgument, err.Error())
+	}
+
+	// Load the serialized public key to a btcec.PublicKey type, in order to
+	// ensure that the:
+	//   * public point is on the secp256k1 elliptic curve.
+	//   * public point coordinates belong to the finite field of secp256k1.
+	//   * public key is well formed (valid magic, length, etc).
+	//
+	// Both compressed and uncompressed public keys are accepted.
+	//
+	// Using addresses encoded from incorrect public keys may lead to
+	// irrevocable fund loss.
+	publicKey, err := btcec.ParsePubKey(request.PublicKey, btcec.S256())
+	if err != nil {
+		return nil, status.Errorf(codes.InvalidArgument, err.Error())
+	}
+
+	// Calculate the RIPEMD160 of the SHA256 of a public key, aka HASH160.
+	//
+	// As per Bitcoin protocol, the serialized public key MUST be compressed
+	// for P2SH-P2WPKH and P2WPKH addresses, whereas P2PKH addresses could be
+	// either compressed or uncompressed. Regarding P2PKH addresses, the
+	// convention at Ledger and in Bitcoin Wiki examples is to use compressed
+	// public keys.
+	publicKeyHash := btcutil.Hash160(publicKey.SerializeCompressed())
+
+	address, err := func() (btcutil.Address, error) {
+		switch request.Encoding {
+		case pb.AddressEncoding_ADDRESS_ENCODING_P2PKH:
+			// Ref: https://en.bitcoin.it/wiki/Technical_background_of_version_1_Bitcoin_addresses
+			return btcutil.NewAddressPubKeyHash(publicKeyHash, chainParams)
+		case pb.AddressEncoding_ADDRESS_ENCODING_P2SH_P2WPKH:
+			// Ref: https://bitcoincore.org/en/segwit_wallet_dev/#creation-of-p2sh-p2wpkh-address
+
+			// Create a P2WPKH native-segwit address
+			p2wpkhAddress, err := btcutil.NewAddressWitnessPubKeyHash(publicKeyHash, chainParams)
+			if err != nil {
+				return nil, err
+			}
+
+			// Create a P2SH redeemScript that pays to the P2WPKH address.
+			//
+			// The redeemScript is 22 bytes long, and starts with a OP_0,
+			// followed by a canonical push of the keyhash. The keyhash
+			// is HASH160 of the 33-byte compressed public key.
+			//
+			// scriptSig: OP_0 <hash160(compressed public key)>
+			redeemScript, err := txscript.PayToAddrScript(p2wpkhAddress)
+			if err != nil {
+				return nil, err
+			}
+
+			return btcutil.NewAddressScriptHash(redeemScript, chainParams)
+		case pb.AddressEncoding_ADDRESS_ENCODING_P2WPKH:
+			// Ref: https://bitcoincore.org/en/segwit_wallet_dev/#native-pay-to-witness-public-key-hash-p2wpkh
+			return btcutil.NewAddressWitnessPubKeyHash(publicKeyHash, chainParams)
+		default:
+			return nil, btcutil.ErrUnknownAddressType
+		}
+	}()
+
+	if err != nil {
+		return nil, status.Errorf(codes.Internal, err.Error())
+	}
+
+	return &pb.EncodeAddressResponse{Address: address.EncodeAddress()}, nil
 }
 
 func getChainParams(params *pb.ChainParams) (*chaincfg.Params, error) {

--- a/pkg/bitcoin/address_test.go
+++ b/pkg/bitcoin/address_test.go
@@ -170,3 +170,355 @@ func TestService_ValidateAddress(t *testing.T) {
 		})
 	}
 }
+
+func TestEncodeAddress(t *testing.T) {
+	// Helper to derive extended key and return the serialized public key.
+	// Use this in unit-tests to ensure extended key derivation and address
+	// encoding work together as expected.
+	derivePublicKey := func(extendedKey string, derivation []uint32) []byte {
+		ctx := context.Background()
+		s := &Service{}
+
+		request := &pb.DeriveExtendedKeyRequest{
+			ExtendedKey: extendedKey,
+			Derivation:  derivation,
+		}
+		response, err := s.DeriveExtendedKey(ctx, request)
+		if err != nil {
+			panic(err)
+		}
+
+		return response.PublicKey
+	}
+
+	tests := []struct {
+		name    string
+		request *pb.EncodeAddressRequest
+		want    *pb.EncodeAddressResponse
+		wantErr *status.Status
+	}{
+		{
+			// https://github.com/LedgerHQ/lib-ledger-core/blob/978a496/core/test/bitcoin/address_test.cpp#L89
+			name: "xpub P2PKH",
+			request: &pb.EncodeAddressRequest{
+				PublicKey: derivePublicKey(
+					"xpub6Cc939fyHvfB9pPLWd3bSyyQFvgKbwhidca49jGCM5Hz5ypEPGf9JVXB4NBuUfPgoHnMjN6oNgdC9KRqM11RZtL8QLW6rFKziNwHDYhZ6Kx",
+					[]uint32{1, 1},
+				),
+				Encoding:    pb.AddressEncoding_ADDRESS_ENCODING_P2PKH,
+				ChainParams: mainnetChainParamsProto,
+			},
+			want: &pb.EncodeAddressResponse{
+				Address: "1AkRBkUZQe5Zqj5syxn1cHCvKUV6DjL9Po",
+			},
+			wantErr: nil,
+		},
+		{
+			// https://github.com/trezor/blockbook/blob/7919486/bchain/coins/btc/bitcoinparser_test.go#L537-L546
+			name: "ypub P2SH-P2WPKH",
+			request: &pb.EncodeAddressRequest{
+				PublicKey: derivePublicKey(
+					"ypub6Ww3ibxVfGzLrAH1PNcjyAWenMTbbAosGNB6VvmSEgytSER9azLDWCxoJwW7Ke7icmizBMXrzBx9979FfaHxHcrArf3zbeJJJUZPf663zsP",
+					[]uint32{0, 0}),
+				Encoding:    pb.AddressEncoding_ADDRESS_ENCODING_P2SH_P2WPKH,
+				ChainParams: mainnetChainParamsProto,
+			},
+			want: &pb.EncodeAddressResponse{
+				Address: "37VucYSaXLCAsxYyAPfbSi9eh4iEcbShgf",
+			},
+			wantErr: nil,
+		},
+		{
+			// https://github.com/trezor/blockbook/blob/7919486/bchain/coins/btc/bitcoinparser_test.go#L549-L558
+			name: "zpub P2WPKH",
+			request: &pb.EncodeAddressRequest{
+				PublicKey: derivePublicKey(
+					"zpub6rFR7y4Q2AijBEqTUquhVz398htDFrtymD9xYYfG1m4wAcvPhXNfE3EfH1r1ADqtfSdVCToUG868RvUUkgDKf31mGDtKsAYz2oz2AGutZYs",
+					[]uint32{0, 0}),
+				Encoding:    pb.AddressEncoding_ADDRESS_ENCODING_P2WPKH,
+				ChainParams: mainnetChainParamsProto,
+			},
+			want: &pb.EncodeAddressResponse{
+				Address: "bc1qcr8te4kr609gcawutmrza0j4xv80jy8z306fyu",
+			},
+			wantErr: nil,
+		},
+		{
+			// generated using https://gist.github.com/onyb/c022bc1a35aae47a327ce5356f2c6a31
+			name: "tpub P2PKH",
+			request: &pb.EncodeAddressRequest{
+				PublicKey: derivePublicKey(
+					"tpubDC5FSnBiZDMmhiuCmWAYsLwgLYrrT9rAqvTySfuCCrgsWz8wxMXUS9Tb9iVMvcRbvFcAHGkMD5Kx8koh4GquNGNTfohfk7pgjhaPCdXpoba",
+					[]uint32{0, 0}),
+				Encoding:    pb.AddressEncoding_ADDRESS_ENCODING_P2PKH,
+				ChainParams: testnet3ChainParamsProto,
+			},
+			want: &pb.EncodeAddressResponse{
+				Address: "mkpZhYtJu2r87Js3pDiWJDmPte2NRZ8bJV",
+			},
+			wantErr: nil,
+		},
+		{
+			// https://github.com/trezor/blockbook/blob/7919486/bchain/coins/btc/bitcoinparser_test.go#L559-L569
+			name: "upub P2SH-P2WPKH",
+			request: &pb.EncodeAddressRequest{
+				PublicKey: derivePublicKey(
+					"upub5DR1Mg5nykixzYjFXWW5GghAU7dDqoPVJ2jrqFbL8sJ7Hs7jn69MP7KBnnmxn88GeZtnH8PRKV9w5MMSFX8AdEAoXY8Qd8BJPoXtpMeHMxJ",
+					[]uint32{0, 0}),
+				Encoding:    pb.AddressEncoding_ADDRESS_ENCODING_P2SH_P2WPKH,
+				ChainParams: testnet3ChainParamsProto,
+			},
+			want: &pb.EncodeAddressResponse{
+				Address: "2N4Q5FhU2497BryFfUgbqkAJE87aKHUhXMp",
+			},
+			wantErr: nil,
+		},
+		{
+			// generated using https://gist.github.com/onyb/c022bc1a35aae47a327ce5356f2c6a31
+			name: "vpub P2WPKH",
+			request: &pb.EncodeAddressRequest{
+				PublicKey: derivePublicKey(
+					"vpub5Y6cjg78GGuNLsaPhmYsiw4gYX3HoQiRBiSwDaBXKUafCt9bNwWQiitDk5VZ5BVxYnQdwoTyXSs2JHRPAgjAvtbBrf8ZhDYe2jWAqvZVnsc",
+					[]uint32{1, 1}),
+				Encoding:    pb.AddressEncoding_ADDRESS_ENCODING_P2WPKH,
+				ChainParams: testnet3ChainParamsProto,
+			},
+			want: &pb.EncodeAddressResponse{
+				Address: "tb1qkwgskuzmmwwvqajnyr7yp9hgvh5y45kg8wvdmd",
+			},
+			wantErr: nil,
+		},
+		{
+			// https://en.bitcoin.it/wiki/Technical_background_of_version_1_Bitcoin_addresses
+			name: "pubkey P2PKH mainnet",
+			request: &pb.EncodeAddressRequest{
+				PublicKey: []byte{
+					0x02, 0x50, 0x86, 0x3a, 0xd6, 0x4a, 0x87, 0xae,
+					0x8a, 0x2f, 0xe8, 0x3c, 0x1a, 0xf1, 0xa8, 0x40,
+					0x3c, 0xb5, 0x3f, 0x53, 0xe4, 0x86, 0xd8, 0x51,
+					0x1d, 0xad, 0x8a, 0x04, 0x88, 0x7e, 0x5b, 0x23,
+					0x52,
+				},
+				Encoding:    pb.AddressEncoding_ADDRESS_ENCODING_P2PKH,
+				ChainParams: mainnetChainParamsProto,
+			},
+			want: &pb.EncodeAddressResponse{
+				Address: "1PMycacnJaSqwwJqjawXBErnLsZ7RkXUAs",
+			},
+			wantErr: nil,
+		},
+		{
+			// http://bitcoinscri.pt/pages/segwit_p2sh_p2wpkh_address
+			name: "pubkey P2SH-P2WPKH mainnet",
+			request: &pb.EncodeAddressRequest{
+				PublicKey: []byte{
+					0x02, 0xf1, 0x18, 0xcc, 0x40, 0x97, 0x75, 0x41,
+					0x9a, 0x93, 0x1c, 0x57, 0x66, 0x4d, 0x0c, 0x19,
+					0xc4, 0x05, 0xe8, 0x56, 0xac, 0x0e, 0xe2, 0xf0,
+					0xe2, 0xa4, 0x13, 0x7d, 0x82, 0x50, 0x53, 0x11,
+					0x28,
+				},
+				Encoding:    pb.AddressEncoding_ADDRESS_ENCODING_P2SH_P2WPKH,
+				ChainParams: mainnetChainParamsProto,
+			},
+			want: &pb.EncodeAddressResponse{
+				Address: "3Mwz6cg8Fz81B7ukexK8u8EVAW2yymgWNd",
+			},
+			wantErr: nil,
+		},
+		{
+			// http://bitcoinscri.pt/pages/segwit_native_p2wpkh_address
+			name: "pubkey P2WPKH mainnet",
+			request: &pb.EncodeAddressRequest{
+				PublicKey: []byte{
+					0x02, 0x53, 0x0c, 0x54, 0x8d, 0x40, 0x26, 0x70,
+					0xb1, 0x3a, 0xd8, 0x88, 0x7f, 0xf9, 0x9c, 0x29,
+					0x4e, 0x67, 0xfc, 0x18, 0x09, 0x7d, 0x23, 0x6d,
+					0x57, 0x88, 0x0c, 0x69, 0x26, 0x1b, 0x42, 0xde,
+					0xf7,
+				},
+				Encoding:    pb.AddressEncoding_ADDRESS_ENCODING_P2WPKH,
+				ChainParams: mainnetChainParamsProto,
+			},
+			want: &pb.EncodeAddressResponse{
+				Address: "bc1qg9stkxrszkdqsuj92lm4c7akvk36zvhqw7p6ck",
+			},
+			wantErr: nil,
+		},
+		// TODO: add pubkey P2PKH testnet3
+		// TODO: add pubkey P2SH-P2WPKH testnet3
+		{
+			// https://github.com/libbitcoin/libbitcoin-system/blob/4dda9d0/test/wallet/witness_address.cpp#L82-L93
+			name: "pubkey P2WPKH testnet3",
+			request: &pb.EncodeAddressRequest{
+				PublicKey: []byte{
+					0x03, 0x82, 0x62, 0xa6, 0xc6, 0xce, 0xc9, 0x3c,
+					0x2d, 0x3e, 0xcd, 0x6c, 0x60, 0x72, 0xef, 0xea,
+					0x86, 0xd0, 0x2f, 0xf8, 0xe3, 0x32, 0x8b, 0xbd,
+					0x02, 0x42, 0xb2, 0x0a, 0xf3, 0x42, 0x59, 0x90,
+					0xac,
+				},
+				Encoding:    pb.AddressEncoding_ADDRESS_ENCODING_P2WPKH,
+				ChainParams: testnet3ChainParamsProto,
+			},
+			want: &pb.EncodeAddressResponse{
+				Address: "tb1qr47dd36u96r0fjle36hdygdnp0v6pwfgqe6jxg",
+			},
+			wantErr: nil,
+		},
+		{
+			// https://github.com/LedgerHQ/lib-ledger-core/blob/8c068f/core/test/integration/BaseFixture.cpp#L75-L77
+			// https://github.com/LedgerHQ/lib-ledger-core/blob/2e5500a/core/test/integration/keychains/p2sh_keychain_test.cpp#L43-L48
+			name: "non-standard key P2SH-P2WPKH",
+			request: &pb.EncodeAddressRequest{
+				PublicKey: derivePublicKey(
+					"tpubDCcvqEHx7prGddpWTfEviiew5YLMrrKy4oJbt14teJZenSi6AYMAs2SNXwYXFzkrNYwECSmobwxESxMCrpfqw4gsUt88bcr8iMrJmbb8P2q",
+					[]uint32{0, 0}),
+				Encoding:    pb.AddressEncoding_ADDRESS_ENCODING_P2SH_P2WPKH,
+				ChainParams: testnet3ChainParamsProto,
+			},
+			want: &pb.EncodeAddressResponse{
+				Address: "2MvuUMAG1NFQmmM69Writ6zTsYCnQHFG9BF",
+			},
+			wantErr: nil,
+		},
+		{
+			// https://github.com/LedgerHQ/lib-ledger-core/blob/8c068fc/core/test/integration/BaseFixture.cpp#L42-L44
+			// Instances of the address spread across the integration tests.
+			name: "non-standard key P2WPKH",
+			request: &pb.EncodeAddressRequest{
+				PublicKey: derivePublicKey(
+					"xpub6CMeLkY9TzXyLYXPWMXB5LWtprVABb6HwPEPXnEgESMNrSUBsvhXNsA7zKS1ZRKhUyQG4HjZysEP8v7gDNU4J6PvN5yLx4meEm3mpEapLMN",
+					[]uint32{0, 0}),
+				Encoding:    pb.AddressEncoding_ADDRESS_ENCODING_P2WPKH,
+				ChainParams: mainnetChainParamsProto,
+			},
+			want: &pb.EncodeAddressResponse{
+				Address: "bc1qh4kl0a0a3d7su8udc2rn62f8w939prqpl34z86",
+			},
+			wantErr: nil,
+		},
+		{
+			// https://github.com/LedgerHQ/lib-ledger-core/blob/8c068fc/core/test/integration/BaseFixture.cpp#L46-L50
+			// Address verified on https://iancoleman.io/bitcoin-key-compression
+			name: "uncompressed pubkey P2PKH",
+			request: &pb.EncodeAddressRequest{
+				PublicKey: []byte{
+					0x04, 0x37, 0xbc, 0x83, 0xa3, 0x77, 0xea, 0x02,
+					0x5e, 0x53, 0xea, 0xfc, 0xd1, 0x8f, 0x29, 0x92,
+					0x68, 0xd1, 0xce, 0xca, 0xe8, 0x9b, 0x4f, 0x15,
+					0x40, 0x19, 0x26, 0xa0, 0xf8, 0xb0, 0x06, 0xc0,
+					0xf7, 0xee, 0x1b, 0x99, 0x50, 0x47, 0xb3, 0xe1,
+					0x59, 0x59, 0xc5, 0xd1, 0x0d, 0xd1, 0x56, 0x3e,
+					0x22, 0xa2, 0xe6, 0xe4, 0xbe, 0x95, 0x72, 0xaa,
+					0x70, 0x78, 0xe3, 0x2f, 0x31, 0x76, 0x77, 0xa9,
+					0x01,
+				},
+				Encoding:    pb.AddressEncoding_ADDRESS_ENCODING_P2PKH,
+				ChainParams: mainnetChainParamsProto,
+			},
+			want: &pb.EncodeAddressResponse{
+				Address: "18iytmdAvJcQwCHWfWppDB5hR3YHNsYhRr",
+			},
+			wantErr: nil,
+		},
+		{
+			name: "xpub P2PKH invalid chain params",
+			request: &pb.EncodeAddressRequest{
+				PublicKey: derivePublicKey(
+					"xpub6Cc939fyHvfB9pPLWd3bSyyQFvgKbwhidca49jGCM5Hz5ypEPGf9JVXB4NBuUfPgoHnMjN6oNgdC9KRqM11RZtL8QLW6rFKziNwHDYhZ6Kx",
+					[]uint32{1, 1},
+				),
+				Encoding:    pb.AddressEncoding_ADDRESS_ENCODING_P2PKH,
+				ChainParams: invalidChainParamsProto,
+			},
+			want: nil,
+			wantErr: status.New(codes.InvalidArgument,
+				ErrUnknownNetwork("99999").Error()),
+		},
+		{
+			name: "invalid length public key",
+			request: &pb.EncodeAddressRequest{
+				PublicKey:   []byte{0x04},
+				Encoding:    pb.AddressEncoding_ADDRESS_ENCODING_P2WPKH,
+				ChainParams: mainnetChainParamsProto,
+			},
+			want: nil,
+			wantErr: status.New(codes.InvalidArgument,
+				"invalid pub key length 1"),
+		},
+		{
+			// https://github.com/btcsuite/btcd/blob/69773a7/btcec/pubkey_test.go#L162-L174
+			name: "invalid public key (X > P)",
+			request: &pb.EncodeAddressRequest{
+				PublicKey: []byte{
+					0x04, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF,
+					0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF,
+					0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF,
+					0xFF, 0xFF, 0xFF, 0xFF, 0xFE, 0xFF, 0xFF, 0xFD,
+					0x2F, 0xb2, 0xe0, 0xea, 0xdd, 0xfb, 0x84, 0xcc,
+					0xf9, 0x74, 0x44, 0x64, 0xf8, 0x2e, 0x16, 0x0b,
+					0xfa, 0x9b, 0x8b, 0x64, 0xf9, 0xd4, 0xc0, 0x3f,
+					0x99, 0x9b, 0x86, 0x43, 0xf6, 0x56, 0xb4, 0x12,
+					0xa3,
+				},
+				Encoding:    pb.AddressEncoding_ADDRESS_ENCODING_P2WPKH,
+				ChainParams: mainnetChainParamsProto,
+			},
+			want: nil,
+			wantErr: status.New(codes.InvalidArgument,
+				"pubkey X parameter is >= to P"),
+		},
+		{
+			// https://github.com/decred/dcrd/blob/b60c60f/dcrec/secp256k1/pubkey_test.go#L105-L109
+			name: "invalid public key (not on curve)",
+			request: &pb.EncodeAddressRequest{
+				PublicKey: []byte{
+					0x03, 0xce, 0x0b, 0x14, 0xfb, 0x84, 0x2b, 0x1b,
+					0xa5, 0x49, 0xfd, 0xd6, 0x75, 0xc9, 0x80, 0x75,
+					0xf1, 0x2e, 0x9c, 0x51, 0x0f, 0x8e, 0xf5, 0x2b,
+					0xd0, 0x21, 0xa9, 0xa1, 0xf4, 0x80, 0x9d, 0x3b,
+					0x4c,
+				},
+				Encoding:    pb.AddressEncoding_ADDRESS_ENCODING_P2WPKH,
+				ChainParams: mainnetChainParamsProto,
+			},
+			want: nil,
+			wantErr: status.New(codes.InvalidArgument,
+				"invalid square root"), // FIXME: Improve error in btcd
+		},
+	}
+
+	ctx := context.Background()
+	s := &Service{}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := s.EncodeAddress(ctx, tt.request)
+			grpcErr := status.Convert(err)
+
+			if grpcErr != nil && tt.wantErr == nil {
+				t.Errorf("unexpected error in EncodeAddress(): %v", grpcErr.Message())
+				return
+			}
+
+			if tt.wantErr != nil {
+				if grpcErr.Code() != tt.wantErr.Code() {
+					t.Errorf("EncodeAddress() gRPC error code = %v, want %v",
+						grpcErr.Code(), tt.wantErr.Code())
+					return
+				}
+
+				if grpcErr.Message() != tt.wantErr.Message() {
+					t.Errorf("EncodeAddress() gRPC error msg = %v, want %v",
+						grpcErr.Message(), tt.wantErr.Message())
+					return
+				}
+			}
+
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("EncodeAddress() got = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
### What is this about?

JIRA | [`BACK-776`](https://ledgerhq.atlassian.net/browse/BACK-776)
-|-

This PR adds a new `EncodeAddress` method to the `CoinService` gRPC service. Given a serialized public key (compressed or otherwise), and an encoding format, it returns back a string address.

Since public keys do not encode the chain parameters, it must be explicitly passed to the `EncodeAddress` method, using the `chain_params` field.

The following encoding schemes are supported:
  * **P2PKH** →       aka legacy
  * **P2SH-P2WPKH** → aka P2WPKH-in-P2SH, and wrapped segwit
  * **P2WPKH** →      aka native segwit

The implementation is also accompanied with service-level unit-tests. The test vectors were mainly sourced from trusted public repositories. For the few cases without any public test vector, they were generated
using BitcoinJS with the help of the following script: https://gist.github.com/onyb/c022bc1a35aae47a327ce5356f2c6a31

### Cute picture of animal

![](https://media.tenor.com/images/bf4ac591346c0e44d88beff1c8525a9e/tenor.gif)